### PR TITLE
Prevent unsubscribing a listener multiple times

### DIFF
--- a/src/emitter.js
+++ b/src/emitter.js
@@ -17,7 +17,8 @@ const emitter = {
 
         return {
             unsubscribe: function () {
-                this.events[event].splice(this.events[event].indexOf(listener), 1);
+                const index = this.events[event].indexOf(listener);
+                if (index !== -1) this.events[event].splice(index, 1);
             }.bind(this)
         };
     }


### PR DESCRIPTION
I found a bug in my own code where I accidentally unsubscribed from an event listener multiple times. Very weird things started happening.

In this scenario, the first time it finds a valid index and unsubscribes as expected. The next time we try to unsubscribe, `indexOf` gets an index of `-1` (since it can't find the listener again), but then uses that index anyways in the `splice` call. This leads to deleting other listeners that should not have been deleted in the first place.

This small PR fixes that by validating that the listener still exists in the array before unsubscribing.